### PR TITLE
Support for CTRL+L to seed multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to the Vz Keymap extension will be documented in this file.
 ### [Unreleased]
 - 改善:
   - CTRL+L（カーソル位置の文字列を選択して検索）でフォーカスが検索ウィジェットに移動しないようにしました。VZエディタの挙動に近づけています。 [#54](https://github.com/tshino/vscode-vz-like-keymap/issues/54)
+  - CTRL+Lで複数行の文字列を検索文字列に設定できるようにしました。複数行の文字列を検索できるVS Codeの機能を活用するため、VZエディタとは異なる動作にしています。 [#62](https://github.com/tshino/vscode-vz-like-keymap/issues/62)
 - 修正:
   - VS Codeの設定によってCTRL+L（カーソル位置の文字列を選択して検索）が効かない場合がある問題を修正しました。 [#57](https://github.com/tshino/vscode-vz-like-keymap/issues/57)
   - (internal) 自動テストのたびにエディタのタブが増えて遅くなる問題を修正。
 - Improved:
   - Changed Ctrl+L (Select word to find) to keep the focus on the document and not move the focus to the find widget. It simulates a similar behavior as the original VZ Editor. [#54](https://github.com/tshino/vscode-vz-like-keymap/issues/54)
+  - Extended Ctrl+L to support seeding multiple-line search strings. This is intentionally different behavior from the original VZ Editor to utilize the feature of VS Code which supports multiple-line search strings. [#62](https://github.com/tshino/vscode-vz-like-keymap/issues/62)
 - Fixed:
   - Ctrl+L (Select word to find) was not working depending on the VS Code settings. [#57](https://github.com/tshino/vscode-vz-like-keymap/issues/57)
   - (internal) Editor tabs ramain open after testing and that slows down the test runs.

--- a/src/search_commands.js
+++ b/src/search_commands.js
@@ -47,10 +47,7 @@ const SearchHandler = function(modeHandler) {
         let expectSync = false;
         if (selectingWordToFind) {
             const sel = textEditor.selection;
-            if (sel.anchor.line !== sel.active.line) {
-                return;
-            }
-            if (sel.anchor.character > sel.active.character) {
+            if (sel.anchor.isAfter(sel.active)) {
                 const sels = Array.from(textEditor.selections).map(
                     sel => new vscode.Selection(sel.start, sel.end)
                 );
@@ -58,21 +55,21 @@ const SearchHandler = function(modeHandler) {
                 mode.expectSync();
                 expectSync = true;
             }
-            if (!EditUtil.isCursorAtEndOfLine(textEditor)) {
+            // if (!EditUtil.isCursorAtEndOfLine(textEditor)) {
                 if (!expectSync) {
                     mode.expectSync();
                     expectSync = true;
                 }
                 await vscode.commands.executeCommand('cursorWordEndRightSelect');
                 await vscode.commands.executeCommand('actions.findWithSelection');
-            } else if (!textEditor.selection.isEmpty) {
-                await vscode.commands.executeCommand('actions.findWithSelection');
-            }
+            // } else if (!textEditor.selection.isEmpty) {
+                // await vscode.commands.executeCommand('actions.findWithSelection');
+            // }
         } else if (!textEditor.selection.isEmpty) {
             await vscode.commands.executeCommand('actions.findWithSelection');
-        } else if (EditUtil.isCursorAtEndOfLine(textEditor)) {
-            await vscode.commands.executeCommand('editor.actions.findWithArgs', { searchString: '' });
-            await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
+        // } else if (EditUtil.isCursorAtEndOfLine(textEditor)) {
+            // await vscode.commands.executeCommand('editor.actions.findWithArgs', { searchString: '' });
+            // await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
         } else {
             mode.expectSync();
             expectSync = true;

--- a/src/search_commands.js
+++ b/src/search_commands.js
@@ -43,6 +43,15 @@ const SearchHandler = function(modeHandler) {
             await vscode.commands.executeCommand('editor.action.startFindReplaceAction');
         }
     );
+    const selectionReachesEndOfDocument = function(textEditor) {
+        let selection = textEditor.selections[0];
+        let lastLine = textEditor.document.lineCount - 1;
+        if (selection.end.line === lastLine &&
+            selection.end.character === textEditor.document.lineAt(lastLine).text.length) {
+            return true;
+        }
+        return false;
+    };
     const selectWordToFindImpl = async function(textEditor, _edit) {
         let expectSync = false;
         if (selectingWordToFind) {
@@ -55,21 +64,21 @@ const SearchHandler = function(modeHandler) {
                 mode.expectSync();
                 expectSync = true;
             }
-            // if (!EditUtil.isCursorAtEndOfLine(textEditor)) {
+            if (!selectionReachesEndOfDocument(textEditor)) {
                 if (!expectSync) {
                     mode.expectSync();
                     expectSync = true;
                 }
                 await vscode.commands.executeCommand('cursorWordEndRightSelect');
                 await vscode.commands.executeCommand('actions.findWithSelection');
-            // } else if (!textEditor.selection.isEmpty) {
-                // await vscode.commands.executeCommand('actions.findWithSelection');
-            // }
+            } else if (!textEditor.selection.isEmpty) {
+                await vscode.commands.executeCommand('actions.findWithSelection');
+            }
         } else if (!textEditor.selection.isEmpty) {
             await vscode.commands.executeCommand('actions.findWithSelection');
-        // } else if (EditUtil.isCursorAtEndOfLine(textEditor)) {
-            // await vscode.commands.executeCommand('editor.actions.findWithArgs', { searchString: '' });
-            // await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
+        } else if (selectionReachesEndOfDocument(textEditor)) {
+            await vscode.commands.executeCommand('editor.actions.findWithArgs', { searchString: '' });
+            await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
         } else {
             mode.expectSync();
             expectSync = true;

--- a/test_with_vscode/suite/keyboard_macro.test.js
+++ b/test_with_vscode/suite/keyboard_macro.test.js
@@ -4877,22 +4877,20 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 1, 6], [2, 0, 2, 3]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        /*
-        it('should not change selection if the cursor is at end of a line', async () => {
-            await resetCursor(1, 13);
+        it('should not change selection if the cursor is at end of the document', async () => {
+            await resetCursor(4, 0);
             const commands = ['vz.selectWordToFind'];
             await recordThroughExecution(commands);
             assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
-            assert.deepStrictEqual(selectionsAsArray(), [[1, 13]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
             await vscode.commands.executeCommand('closeFindWidget');
 
-            await resetCursor(2, 14);
+            await resetCursor(4, 0);
             await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
         });
-        */
 
         it('should select multiple words starting from the cursor position', async () => {
             await resetCursor(2, 0);
@@ -5064,36 +5062,34 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 2, 10]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        /*
-        it('should not change selection if the cursor is at end of a line (case 1)', async () => {
-            await resetCursor(2, 14);
+        it('should not change selection if the cursor is at end of the document (case 1)', async () => {
+            await resetCursor(4, 0);
             const commands = ['vz.expandWordToFind'];
             await recordThroughExecution(commands);
             assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
             await vscode.commands.executeCommand('closeFindWidget');
 
-            await resetCursor(1, 13);
+            await resetCursor(4, 0);
             await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[1, 13]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
         });
-        it('should not change selection if the cursor is at end of a line (case 2)', async () => {
-            await selectRange(2, 11, 2, 14);
+        it('should not change selection if the cursor is at end of the document (case 2)', async () => {
+            await selectRange(3, 7, 4, 0);
             const commands = ['vz.expandWordToFind'];
             await recordThroughExecution(commands);
             assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 2, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[3, 7, 4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
             await vscode.commands.executeCommand('closeFindWidget');
 
-            await selectRange(1, 7, 1, 13);
+            await selectRange(3, 7, 4, 0);
             await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 1, 13]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[3, 7, 4, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        */
         it('should reverse selection if the direction of selection is backward', async () => {
             await selectRange(0, 3, 0, 0);
             const commands = ['vz.expandWordToFind'];

--- a/test_with_vscode/suite/keyboard_macro.test.js
+++ b/test_with_vscode/suite/keyboard_macro.test.js
@@ -4877,7 +4877,8 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 1, 6], [2, 0, 2, 3]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        it('should not change selection if the cursor is at end of a line (case 1)', async () => {
+        /*
+        it('should not change selection if the cursor is at end of a line', async () => {
             await resetCursor(1, 13);
             const commands = ['vz.selectWordToFind'];
             await recordThroughExecution(commands);
@@ -4891,20 +4892,7 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[2, 14]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
         });
-        it('should not change selection if the cursor is at end of a line (case 2)', async () => {
-            await selectRange(1, 7, 1, 13);
-            const commands = ['vz.selectWordToFind'];
-            await recordThroughExecution(commands);
-            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
-            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 1, 13]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), true);
-            await vscode.commands.executeCommand('closeFindWidget');
-
-            await selectRange(2, 11, 2, 14);
-            await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 2, 14]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), true);
-        });
+        */
 
         it('should select multiple words starting from the cursor position', async () => {
             await resetCursor(2, 0);
@@ -4920,12 +4908,40 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 1, 13]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
+        it('should select multiple lines starting from the cursor position', async () => {
+            await resetCursor(2, 11);
+            const commands = ['vz.selectWordToFind', 'vz.selectWordToFind'];
+            await recordThroughExecution(commands);
+            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 3, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+            await vscode.commands.executeCommand('closeFindWidget');
+
+            await resetCursor(1, 7);
+            await kb_macro.replay(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 2, 3]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+        });
         it('should select multiple words starting from the existing selection', async () => {
             await selectRange(2, 0, 2, 3);
             const commands = ['vz.selectWordToFind', 'vz.selectWordToFind'];
             await recordThroughExecution(commands);
             assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
             assert.deepStrictEqual(selectionsAsArray(), [[2, 0, 2, 10]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+            await vscode.commands.executeCommand('closeFindWidget');
+
+            await selectRange(1, 0, 1, 3);
+            await kb_macro.replay(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 1, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+        });
+        it('should select multiple lines starting from the existing selection', async () => {
+            await selectRange(2, 11, 2, 14);
+            const commands = ['vz.selectWordToFind', 'vz.selectWordToFind'];
+            await recordThroughExecution(commands);
+            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 3, 6]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
             await vscode.commands.executeCommand('closeFindWidget');
 
@@ -5006,6 +5022,49 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[3, 7, 3, 10]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
+        it('should select multiple lines (case 1)', async () => {
+            await resetCursor(2, 14);
+            const commands = ['vz.expandWordToFind'];
+            await recordThroughExecution(commands);
+            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 14, 3, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+            await vscode.commands.executeCommand('closeFindWidget');
+
+            await resetCursor(1, 13);
+            await kb_macro.replay(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 13, 2, 3]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+        });
+        it('should select multiple lines (case 2)', async () => {
+            await selectRange(2, 11, 2, 14);
+            const commands = ['vz.expandWordToFind'];
+            await recordThroughExecution(commands);
+            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 3, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+            await vscode.commands.executeCommand('closeFindWidget');
+
+            await selectRange(1, 7, 1, 13);
+            await kb_macro.replay(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 2, 3]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+        });
+        it('should select multiple lines (case 3)', async () => {
+            await selectRange(2, 11, 3, 3);
+            const commands = ['vz.expandWordToFind'];
+            await recordThroughExecution(commands);
+            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 3, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+            await vscode.commands.executeCommand('closeFindWidget');
+
+            await selectRange(1, 7, 2, 3);
+            await kb_macro.replay(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 2, 10]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+        });
+        /*
         it('should not change selection if the cursor is at end of a line (case 1)', async () => {
             await resetCursor(2, 14);
             const commands = ['vz.expandWordToFind'];
@@ -5034,22 +5093,9 @@ describe('KeyboardMacro', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 1, 13]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        it('should not change selection if the selection reaches multiple lines', async () => {
-            await selectRange(2, 11, 3, 3);
-            const commands = ['vz.expandWordToFind'];
-            await recordThroughExecution(commands);
-            assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 3, 3]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), false);
-            await vscode.commands.executeCommand('closeFindWidget');
-
-            await selectRange(1, 7, 2, 3);
-            await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[1, 7, 2, 3]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), false);
-        });
+        */
         it('should reverse selection if the direction of selection is backward', async () => {
-            await selectRange(0, 6, 0, 0);
+            await selectRange(0, 3, 0, 0);
             const commands = ['vz.expandWordToFind'];
             await recordThroughExecution(commands);
             assert.deepStrictEqual(kb_macro.getRecordedCommandNames(), commands);
@@ -5057,9 +5103,9 @@ describe('KeyboardMacro', () => {
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
             await vscode.commands.executeCommand('closeFindWidget');
 
-            await selectRange(2, 14, 2, 11);
+            await selectRange(2, 10, 2, 4);
             await kb_macro.replay(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 11, 2, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[2, 4, 2, 14]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
     });

--- a/test_with_vscode/suite/search_commands.test.js
+++ b/test_with_vscode/suite/search_commands.test.js
@@ -106,6 +106,16 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[5, 7, 5, 10]]);
         });
+        it('should select the text beyond the line end', async () => {
+            await resetCursor(4, 14);
+
+            await searchHandler.selectWordToFind(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 14, 5, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+
+            await vscode.commands.executeCommand('editor.action.previousMatchFindAction');
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 2, 6]]);
+        });
         it('should not change selection if it is not empty (case 1)', async () => {
             await selectRange(2, 0, 2, 3);
 
@@ -136,6 +146,7 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[5, 7, 5, 10]]);
         });
+        /*
         it('should not change selection if the cursor is at end of a line (case 1)', async () => {
             await resetCursor(4, 14);
 
@@ -146,16 +157,7 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
         });
-        it('should not change selection if the cursor is at end of a line (case 2)', async () => {
-            await selectRange(2, 10, 2, 13);
-
-            await searchHandler.selectWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[2, 10, 2, 13]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), true);
-
-            await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 7, 4, 10]]);
-        });
+        */
     });
     describe('selectWordToFind calling multiple times', () => {
         beforeEach(async () => {
@@ -196,6 +198,37 @@ describe('SearchHandler', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[4, 0, 4, 10], [5, 0, 5, 10]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
+        it('should select multiple lines (case 1)', async () => {
+            await resetCursor(4, 11);
+
+            await searchHandler.selectWordToFind(textEditor);
+            await searchHandler.selectWordToFind(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
+
+            await searchHandler.selectWordToFind(textEditor); // '123\nabcdef xyz'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 10]]);
+        });
+        it('should select multiple lines (case 2)', async () => {
+            await resetCursor(4, 14);
+
+            await searchHandler.selectWordToFind(textEditor); // '\nabcdef'
+            await searchHandler.selectWordToFind(textEditor); // '\nabcdef xyz'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 14, 5, 10]]);
+        });
+        it('should select multiple lines (case 3)', async () => {
+            await selectRange(4, 11, 4, 14);
+
+            await searchHandler.selectWordToFind(textEditor); // '123'
+            await searchHandler.selectWordToFind(textEditor); // '123\nabcdef'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
+        });
+        it('should select multiple lines (case 4)', async () => {
+            await selectRange(4, 11, 5, 3);
+
+            await searchHandler.selectWordToFind(textEditor);
+            await searchHandler.selectWordToFind(textEditor); // '123\nabcdef'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
+        });
         it('should select multiple words starting from the existing selection', async () => {
             await selectRange(4, 0, 4, 3);
 
@@ -219,6 +252,7 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[2, 7, 2, 13]]);
         });
+        /*
         it('should not change selection if the cursor is at end of a line (case 1)', async () => {
             await resetCursor(4, 14);
 
@@ -238,16 +272,9 @@ describe('SearchHandler', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 4, 14]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        it('should not change selection if the selection reaches multiple lines', async () => {
-            await selectRange(4, 11, 5, 6);
-
-            await searchHandler.selectWordToFind(textEditor);
-            await searchHandler.selectWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), true);
-        });
+        */
         it('should reverse selection if the direction of selection is backward', async () => {
-            await selectRange(0, 6, 0, 0);
+            await selectRange(0, 3, 0, 0);
 
             await searchHandler.selectWordToFind(textEditor);
             await searchHandler.selectWordToFind(textEditor);
@@ -326,6 +353,37 @@ describe('SearchHandler', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[4, 0, 4, 10], [5, 0, 5, 10]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
+        it('should select multiple lines (case 1)', async () => {
+            await resetCursor(4, 11);
+
+            await searchHandler.expandWordToFind(textEditor);
+            await searchHandler.expandWordToFind(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
+
+            await searchHandler.expandWordToFind(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 10]]); // '123\nabcdef xyz'
+        });
+        it('should select multiple lines (case 2)', async () => {
+            await resetCursor(4, 14);
+
+            await searchHandler.expandWordToFind(textEditor); // '\nabcdef'
+            await searchHandler.expandWordToFind(textEditor); // '\nabcdef xyz'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 14, 5, 10]]);
+        });
+        it('should select multiple lines (case 3)', async () => {
+            await selectRange(4, 11, 4, 14);
+
+            await searchHandler.expandWordToFind(textEditor); // '123\nabcdef'
+            await searchHandler.expandWordToFind(textEditor); // '123\nabcdef xyz'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 10]]);
+        });
+        it('should select multiple lines (case 4)', async () => {
+            await selectRange(4, 11, 5, 3);
+
+            await searchHandler.expandWordToFind(textEditor); // '123\nabcdef'
+            await searchHandler.expandWordToFind(textEditor); // '123\nabcdef xyz'
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 10]]);
+        });
         it('should select an entire word when the first part of the word is already selected', async () => {
             await selectRange(2, 0, 2, 3);
 
@@ -336,6 +394,7 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[2, 7, 2, 13]]);
         });
+        /*
         it('should not change selection if the cursor is at end of a line (case 1)', async () => {
             await resetCursor(4, 14);
 
@@ -353,15 +412,9 @@ describe('SearchHandler', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 4, 14]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        it('should not change selection if the selection reaches multiple lines', async () => {
-            await selectRange(4, 11, 5, 6);
-
-            await searchHandler.expandWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 5, 6]]);
-            assert.strictEqual(searchHandler.isSelectingMatch(), false);
-        });
+        */
         it('should reverse selection if the direction of selection is backward', async () => {
-            await selectRange(0, 6, 0, 0);
+            await selectRange(0, 3, 0, 0);
 
             await searchHandler.expandWordToFind(textEditor);
             assert.deepStrictEqual(selectionsAsArray(), [[0, 0, 0, 6]]);

--- a/test_with_vscode/suite/search_commands.test.js
+++ b/test_with_vscode/suite/search_commands.test.js
@@ -146,18 +146,16 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[5, 7, 5, 10]]);
         });
-        /*
-        it('should not change selection if the cursor is at end of a line (case 1)', async () => {
-            await resetCursor(4, 14);
+        it('should not change selection if the cursor is at end of the document', async () => {
+            await resetCursor(6, 0);
 
             await searchHandler.selectWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
 
-            await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            await vscode.commands.executeCommand('editor.action.previousMatchFindAction');
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
         });
-        */
     });
     describe('selectWordToFind calling multiple times', () => {
         beforeEach(async () => {
@@ -252,27 +250,25 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[2, 7, 2, 13]]);
         });
-        /*
-        it('should not change selection if the cursor is at end of a line (case 1)', async () => {
-            await resetCursor(4, 14);
+        it('should not change selection if the cursor is at end of the document (case 1)', async () => {
+            await resetCursor(6, 0);
 
             await searchHandler.selectWordToFind(textEditor);
             await searchHandler.selectWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
 
-            await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            await vscode.commands.executeCommand('editor.action.previousMatchFindAction');
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
         });
-        it('should not change selection if the cursor is at end of a line (case 2)', async () => {
-            await selectRange(4, 11, 4, 14);
+        it('should not change selection if the cursor is at end of the document (case 2)', async () => {
+            await selectRange(5, 7, 6, 0);
 
             await searchHandler.selectWordToFind(textEditor);
             await searchHandler.selectWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 4, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[5, 7, 6, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        */
         it('should reverse selection if the direction of selection is backward', async () => {
             await selectRange(0, 3, 0, 0);
 
@@ -394,25 +390,23 @@ describe('SearchHandler', () => {
             await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
             assert.deepStrictEqual(selectionsAsArray(), [[2, 7, 2, 13]]);
         });
-        /*
-        it('should not change selection if the cursor is at end of a line (case 1)', async () => {
-            await resetCursor(4, 14);
+        it('should not change selection if the cursor is at end of the document (case 1)', async () => {
+            await resetCursor(6, 0);
 
             await searchHandler.expandWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), false);
 
-            await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 14]]);
+            await vscode.commands.executeCommand('editor.action.previousMatchFindAction');
+            assert.deepStrictEqual(selectionsAsArray(), [[6, 0]]);
         });
-        it('should not change selection if the cursor is at end of a line (case 2)', async () => {
-            await selectRange(4, 11, 4, 14);
+        it('should not change selection if the cursor is at end of the document (case 2)', async () => {
+            await selectRange(5, 7, 6, 0);
 
             await searchHandler.expandWordToFind(textEditor);
-            assert.deepStrictEqual(selectionsAsArray(), [[4, 11, 4, 14]]);
+            assert.deepStrictEqual(selectionsAsArray(), [[5, 7, 6, 0]]);
             assert.strictEqual(searchHandler.isSelectingMatch(), true);
         });
-        */
         it('should reverse selection if the direction of selection is backward', async () => {
             await selectRange(0, 3, 0, 0);
 

--- a/test_with_vscode/suite/search_commands.test.js
+++ b/test_with_vscode/suite/search_commands.test.js
@@ -77,7 +77,7 @@ describe('SearchHandler', () => {
                     'xyz abcdef 123\n' +
                     'abcdef xyz\n'
                 ),
-                vscode.EndOfLine.CRLF
+                vscode.EndOfLine.LF
             );
             textEditor.selections = [ new vscode.Selection(0, 0, 0, 0) ];
             mode.initialize(textEditor);
@@ -117,6 +117,16 @@ describe('SearchHandler', () => {
             assert.deepStrictEqual(selectionsAsArray(), [[2, 7, 2, 10]]);
         });
         it('should not change selection if it is not empty (case 2)', async () => {
+            await selectRange(1, 0, 2, 6); // '\nabcdef' (multiple lines)
+
+            await searchHandler.selectWordToFind(textEditor);
+            assert.deepStrictEqual(selectionsAsArray(), [[1, 0, 2, 6]]);
+            assert.strictEqual(searchHandler.isSelectingMatch(), true);
+
+            await vscode.commands.executeCommand('editor.action.nextMatchFindAction');
+            assert.deepStrictEqual(selectionsAsArray(), [[4, 14, 5, 6]]);
+        });
+        it('should not change selection if it is not empty (case 3)', async () => {
             await selectRanges([[4, 0, 4, 3], [5, 0, 5, 6]]);
 
             await searchHandler.selectWordToFind(textEditor);
@@ -159,7 +169,7 @@ describe('SearchHandler', () => {
                     'xyz abcdef 123\n' +
                     'abcdef xyz\n'
                 ),
-                vscode.EndOfLine.CRLF
+                vscode.EndOfLine.LF
             );
             textEditor.selections = [ new vscode.Selection(0, 0, 0, 0) ];
             mode.initialize(textEditor);


### PR DESCRIPTION
fixes #62

- [x] `vz.selectWordToFind` seeds multiple-line search string from selection
- [x] `vz.selectWordToFind` extends search string beyond line end
- [x] `vz.expandWordToFind` seeds multiple-line search string from selection
- [x] `vz.expandWordToFind` extends search string beyond line end
