### PR TITLE
Fix tests of jumpToBracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Vz Keymap extension will be documented in this file.
 
+### [Unreleased]
+- 修正:
+  - (内部) `vz.jumpToBracket` コマンドのテストがVS Code 1.67.0で失敗するのを修正しました。 [#74](https://github.com/tshino/vscode-vz-like-keymap/pull/74)
+- Fixed:
+  - (internal) Tests for `vz.jumpToBracket` is failing with VS Code 1.67.0. [#74](https://github.com/tshino/vscode-vz-like-keymap/pull/74)
+
 ### [0.19.1] - 2022-05-05
 - 新規:
   - (internal) 自動テストにeslintの実行を追加。 [#69](https://github.com/tshino/vscode-vz-like-keymap/pull/69)

--- a/test_with_vscode/suite/cursor_commands.test.js
+++ b/test_with_vscode/suite/cursor_commands.test.js
@@ -1197,7 +1197,9 @@ describe('CursorHandler', () => {
                 'aaaa( bbbb )\n' +
                 '{\n' +
                 '    { cccc }\n' +
-                '}\n'
+                '}\n',
+                vscode.EndOfLine.LF,
+                'javascript'
             );
         });
         it('should move cursor to opposite side of the pair of bracket', async () => {

--- a/test_with_vscode/suite/keyboard_macro.test.js
+++ b/test_with_vscode/suite/keyboard_macro.test.js
@@ -1357,7 +1357,9 @@ describe('KeyboardMacro', () => {
                 'aaaa( bbbb )\n' +
                 '{\n' +
                 '    { cccc }\n' +
-                '}\n'
+                '}\n',
+                vscode.EndOfLine.LF,
+                'javascript'
             );
         });
         it('should move cursor to opposite side of the pair of bracket', async () => {


### PR DESCRIPTION
VS Code 1.67.0 になってから jumpToBracket コマンドのテストが失敗するようになった。
どうやら plaintext ではVS Code組み込みの Go To Bracket コマンドが働かなくなったのが原因。
しかたないので、テストでは javascript を使うように書き換える。