### PR TITLE
Add Interactive Playground keys support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,16 @@
 All notable changes to the Vz Keymap extension will be documented in this file.
 
 ### [Unrelease]
+- 新規:
+    - Interactive Playgroundページのスクロール操作に対応しました。 [#171](https://github.com/tshino/vscode-vz-like-keymap/pull/171)
+        - CTRL+E, CTRL+X, CTRL+R, CTRL+C でスクロール。
+        - これらは設定の 'Vz Keymap: Interactive Playground Keys' で有効化できます。
 - 修正:
     - Settings画面で使うキー定義を更新。 [#160](https://github.com/tshino/vscode-vz-like-keymap/pull/160)
+- New:
+    - Added scroll keys support in Interactive Playground pages. [#171](https://github.com/tshino/vscode-vz-like-keymap/pull/171)
+        - Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C to scroll.
+        - These keys are enabled by turning on the 'Vz Keymap: Interactive Playground Keys' in the Settings.
 - Fixed:
     - Updated key definitions for the Settings page. [#160](https://github.com/tshino/vscode-vz-like-keymap/pull/160)
 

--- a/package.json
+++ b/package.json
@@ -231,6 +231,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enables vz-style keys to select Code Action menu\n(Ctrl+E, Ctrl+X, Ctrl+M)"
+                },
+                "vzKeymap.interactivePlaygroundKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to scroll in Interactive Playground page\n(Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C)"
                 }
             }
         },
@@ -1319,6 +1324,26 @@
                 "key": "ctrl+m",
                 "command": "acceptSelectedCodeAction",
                 "when": "codeActionMenuVisible && config.vzKeymap.codeActionKeys"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "workbench.action.interactivePlayground.arrowUp",
+                "when": "interactivePlaygroundFocus && !editorTextFocus && config.vzKeymap.interactivePlaygroundKeys"
+            },
+            {
+                "key": "ctrl+x",
+                "command": "workbench.action.interactivePlayground.arrowDown",
+                "when": "interactivePlaygroundFocus && !editorTextFocus && config.vzKeymap.interactivePlaygroundKeys"
+            },
+            {
+                "key": "ctrl+r",
+                "command": "workbench.action.interactivePlayground.pageUp",
+                "when": "interactivePlaygroundFocus && !editorTextFocus && config.vzKeymap.interactivePlaygroundKeys"
+            },
+            {
+                "key": "ctrl+c",
+                "command": "workbench.action.interactivePlayground.pageDown",
+                "when": "interactivePlaygroundFocus && !editorTextFocus && config.vzKeymap.interactivePlaygroundKeys"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
                 "vzKeymap.interactivePlaygroundKeys": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Enables vz-style keys to scroll in Interactive Playground page\n(Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C)"
+                    "description": "Enables vz-style keys to scroll in Interactive Playground pages\n(Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C)"
                 }
             }
         },


### PR DESCRIPTION
Interactive Playgroundというページ（`Help: Interactive Editor Playground` というコマンドで開くことができる）上のスクロール操作が、普通のカーソルキーに割り当てられた特殊なコマンドだったので、Vz風キーでも操作できるようにした。
