### PR TITLE
Add Editor Hover keys support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ All notable changes to the Vz Keymap extension will be documented in this file.
 - 新規:
     - Interactive Playgroundページのスクロール操作に対応しました。 [#171](https://github.com/tshino/vscode-vz-like-keymap/pull/171)
         - CTRL+E, CTRL+X, CTRL+R, CTRL+C でスクロール。
-        - これらは設定の 'Vz Keymap: Interactive Playground Keys' で有効化できます。
+        - これらは設定の 'Vz Keymap: Interactive Playground Keys' で有効化できます。デフォルトで有効です。
+    - Editor Hover領域のスクロール操作に対応しました。 [#172](https://github.com/tshino/vscode-vz-like-keymap/pull/172)
+        - CTRL+E, CTRL+X, CTRL+S, CTRL+D, CTRL+R, CTRL+C, CTRL+Q R, CTRL+Q C でスクロール。
+        - これらは設定の 'Vz Keymap: Editor Hover Keys' で有効化できます。デフォルトで有効です。
 - 修正:
     - Settings画面で使うキー定義を更新。 [#160](https://github.com/tshino/vscode-vz-like-keymap/pull/160)
 - New:
     - Added scroll keys support in Interactive Playground pages. [#171](https://github.com/tshino/vscode-vz-like-keymap/pull/171)
         - Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C to scroll.
         - These keys are enabled by turning on the 'Vz Keymap: Interactive Playground Keys' in the Settings.
+    - Added scroll keys support in Editor Hovers. [#172](https://github.com/tshino/vscode-vz-like-keymap/pull/172)
+        - Ctrl+E, Ctrl+X, Ctrl+S, Ctrl+D, Ctrl+R, Ctrl+C, Ctrl+Q R, Ctrl+Q C to scroll.
+        - These keys are enabled by turning on the 'Vz Keymap: Editor Hover Keys' in the Settings.
 - Fixed:
     - Updated key definitions for the Settings page. [#160](https://github.com/tshino/vscode-vz-like-keymap/pull/160)
 

--- a/package.json
+++ b/package.json
@@ -236,6 +236,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enables vz-style keys to scroll in Interactive Playground pages\n(Ctrl+E, Ctrl+X, Ctrl+R, Ctrl+C)"
+                },
+                "vzKeymap.editorHoverKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to scroll in Editor Hovers\n(Ctrl+E, Ctrl+X, Ctrl+S, Ctrl+D, Ctrl+R, Ctrl+C, Ctrl+Q R, Ctrl+Q C)"
                 }
             }
         },
@@ -1344,6 +1349,56 @@
                 "key": "ctrl+c",
                 "command": "workbench.action.interactivePlayground.pageDown",
                 "when": "interactivePlaygroundFocus && !editorTextFocus && config.vzKeymap.interactivePlaygroundKeys"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "editor.action.scrollUpHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+x",
+                "command": "editor.action.scrollDownHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+s",
+                "command": "editor.action.scrollLeftHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+d",
+                "command": "editor.action.scrollRightHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+r",
+                "command": "editor.action.pageUpHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+c",
+                "command": "editor.action.pageDownHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+q ctrl+r",
+                "command": "editor.action.goToTopHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+q r",
+                "command": "editor.action.goToTopHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+q ctrl+c",
+                "command": "editor.action.goToBottomHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+q c",
+                "command": "editor.action.goToBottomHover",
+                "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
             }
         ]
     },


### PR DESCRIPTION
Editor Hoverと呼ばれる関数の説明などが表示される領域のスクロール操作をダイアモンドカーソルでもできるようにする。
それらの操作はキーボードショートカットで `hover` で検索すると見つかり、`editorHoverFocused` という条件で定義されている。
なお、この操作はEditor Hover領域が表示されているだけでは不十分で、フォーカスされている場合のみ有効なことに注意。