### PR TITLE
Update list view keys to match corresponding default keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Vz Keymap extension will be documented in this file.
 
+### [Unreleased]
+- 修正:
+    - リストビューで使うキー定義を更新。 [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
+- Fixed:
+    - Updated key definitions for list views. [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
+
+
 ### [0.19.7] - 2023-06-28
 - 新規:
     - Interactive Playgroundページのスクロール操作に対応しました。 [#171](https://github.com/tshino/vscode-vz-like-keymap/pull/171)

--- a/package.json
+++ b/package.json
@@ -1198,12 +1198,12 @@
             {
                 "key": "ctrl+s",
                 "command": "list.collapse",
-                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys"
+                "when": "listFocus && treeElementCanCollapse && !inputFocus && config.vzKeymap.listViewKeys || listFocus && treeElementHasParent && !inputFocus && config.vzKeymap.listViewKeys"
             },
             {
                 "key": "ctrl+d",
                 "command": "list.expand",
-                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys"
+                "when": "listFocus && treeElementCanExpand && !inputFocus && config.vzKeymap.listViewKeys || listFocus && treeElementHasChild && !inputFocus && config.vzKeymap.listViewKeys"
             },
             {
                 "key": "ctrl+r",


### PR DESCRIPTION
リストビューやツリービューで使うキーの定義をデフォルトキーバインドの更新に合わせて更新。
CTRL+SとCTRL+Dでツリーを開いたり閉じたりする操作のwhen節が細かくなった。
