### PR TITLE
Update suggestion widget keys to match correcponding default keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to the Vz Keymap extension will be documented in this file.
 ### [Unreleased]
 - 修正:
     - リストビューで使うキー定義を更新。 [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
+    - 補完候補リストの操作で使うキー定義を更新。 [#175](https://github.com/tshino/vscode-vz-like-keymap/pull/175)
 - Fixed:
     - Updated key definitions for list views. [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
+    - Updated key definitions for suggestion widgets. [#175](https://github.com/tshino/vscode-vz-like-keymap/pull/175)
 
 
 ### [0.19.7] - 2023-06-28

--- a/package.json
+++ b/package.json
@@ -1243,22 +1243,22 @@
             {
                 "key": "ctrl+e",
                 "command": "selectPrevSuggestion",
-                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys"
+                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion && config.vzKeymap.suggestionWidgetKeys"
             },
             {
                 "key": "ctrl+x",
                 "command": "selectNextSuggestion",
-                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys"
+                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion && config.vzKeymap.suggestionWidgetKeys"
             },
             {
                 "key": "ctrl+r",
                 "command": "selectPrevPageSuggestion",
-                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys"
+                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion && config.vzKeymap.suggestionWidgetKeys"
             },
             {
                 "key": "ctrl+c",
                 "command": "selectNextPageSuggestion",
-                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys"
+                "when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus && config.vzKeymap.suggestionWidgetKeys || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion && config.vzKeymap.suggestionWidgetKeys"
             },
             {
                 "key": "ctrl+q ctrl+r",


### PR DESCRIPTION
補完候補（suggestion）の操作で使うキーの定義をデフォルトキーバインドの更新に合わせて更新。
少し前のVS Codeの更新で、補完候補リストが自動で表示されるときにどれも選択されていない状態から始まるような設定が可能になり、そのときに上下キーを押すと候補の1つにフォーカスが当たるのだが、Vz Keymapで定義しているCTRL+EやCTRL+Xなどが同じ動作をするようになっていなかった。なのでそれを修正。

