### PR TITLE
Support breadcrumbs keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@
 All notable changes to the Vz Keymap extension will be documented in this file.
 
 ### [Unreleased]
+- 新規:
+    - パンくずリストの操作に対応しました。 [#176](https://github.com/tshino/vscode-vz-like-keymap/pull/176)
+        - CTRL+E, CTRL+X, CTRL+S, CTRL+D でリスト操作。
+        - CTRL+A, CTRL+F で列移動。
 - 修正:
     - リストビューで使うキー定義を更新。 [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
     - 補完候補リストの操作で使うキー定義を更新。 [#175](https://github.com/tshino/vscode-vz-like-keymap/pull/175)
+- New:
+    - Added navigation keys support on Breadcrumbds. [#176](https://github.com/tshino/vscode-vz-like-keymap/pull/176)
+        - Ctrl+E, Ctrl+X, Ctrl+S, Ctrl+D to mvoe focus on the list view.
+        - Ctrl+A, Ctrl+F to move across columns.
 - Fixed:
     - Updated key definitions for list views. [#173](https://github.com/tshino/vscode-vz-like-keymap/pull/173)
     - Updated key definitions for suggestion widgets. [#175](https://github.com/tshino/vscode-vz-like-keymap/pull/175)

--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
                     "default": true,
                     "description": "On: Tag Jump / Off: Show Editor Context Menu (VS Code default)"
                 },
+                "vzKeymap.breadcrumbsKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to move focus and select on Breadcrumbs\n(Ctrl+S, Ctrl+D, Ctrl+A, Ctrl+F, Ctrl+X, Ctrl+M)"
+                },
                 "vzKeymap.listViewKeys": {
                     "type": "boolean",
                     "default": true,
@@ -1184,6 +1189,46 @@
                 "key": "ctrl+alt+j",
                 "command": "workbench.action.togglePanel",
                 "when": ""
+            },
+            {
+                "key": "ctrl+f",
+                "command": "breadcrumbs.focusNext",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+d",
+                "command": "breadcrumbs.focusNext",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+a",
+                "command": "breadcrumbs.focusPrevious",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+s",
+                "command": "breadcrumbs.focusPrevious",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+x",
+                "command": "breadcrumbs.selectFocused",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+m",
+                "command": "breadcrumbs.selectFocused",
+                "when": "breadcrumbsActive && breadcrumbsVisible && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+f",
+                "command": "breadcrumbs.focusNextWithPicker",
+                "when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus && config.vzKeymap.breadcrumbsKeys"
+            },
+            {
+                "key": "ctrl+a",
+                "command": "breadcrumbs.focusPreviousWithPicker",
+                "when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus && config.vzKeymap.breadcrumbsKeys"
             },
             {
                 "key": "ctrl+e",


### PR DESCRIPTION
ファイルの階層（親ディレクトリ）やカーソルがある場所のクラスや関数の階層を表示している Breadcrumbs と呼ばれる領域の操作をVZ風にできるようにします。

Breadcrumbs は `CTRL+SHIFT+.` や `CTRL+SHIFT+;` （日本語キーボードでは`CTRL+SHIFT+:`、たぶんMacの場合は`CMD+SHIFT+.`など）でフォーカスできます。
フォーカスしたらカーソル上下左右でリスト上の移動ができ、CTRL押しながらカーソル左右で列を移動できる。
そこで、Vz Keymapではそれらに対応する操作として、

- CTRL+E, CTRL+X, CTRL+S, CTRL+D でリスト操作（これまで通り）
- CTRL+A, CTRL+F で列移動

を割り当ててみる。
