### PR TITLE
Add Search viewlet keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Vz Keymap extension will be documented in this file.
 
+### [Unreleased]
+- 新規:
+    - Searchビューで使う操作に対応しました。 [#181](https://github.com/tshino/vscode-vz-like-keymap/pull/181)
+        - CTRL+W, CTRL+Z で検索入力と検索結果の間でフォーカスを移動。
+        - CTRL+M で検索結果にフォーカスがあるとき選択されたファイルを開く。
+        - これらは設定の 'Vz Keymap: Search Viewlet Keys' で有効化できます。デフォルトで有効です。
+- New:
+    - Added navigation keys support in Search viewlet. [#181](https://github.com/tshino/vscode-vz-like-keymap/pull/181)
+        - Ctrl+W, Ctrl+Z to move focus between the search input box and search result.
+        - Ctrl+M to open the selected file in search result.
+        - These keys are enabled by turning on the 'Vz Keymap: Search Viewlet Keys' in the Settings.
+
 ### [0.19.8] - 2023-07-13
 - 新規:
     - パンくずリストの操作に対応しました。 [#176](https://github.com/tshino/vscode-vz-like-keymap/pull/176)

--- a/package.json
+++ b/package.json
@@ -246,6 +246,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enables vz-style keys to scroll in Editor Hovers\n(Ctrl+E, Ctrl+X, Ctrl+S, Ctrl+D, Ctrl+R, Ctrl+C, Ctrl+Q R, Ctrl+Q C)"
+                },
+                "vzKeymap.searchViewletKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to move focus between panes in the Search viewlet\n(Ctrl+W, Ctrl+Z, Ctrl+M)"
                 }
             }
         },
@@ -1444,6 +1449,21 @@
                 "key": "ctrl+q c",
                 "command": "editor.action.goToBottomHover",
                 "when": "editorHoverFocused && config.vzKeymap.editorHoverKeys"
+            },
+            {
+                "key": "ctrl+w",
+                "command": "search.focus.previousInputBox",
+                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys"
+            },
+            {
+                "key": "ctrl+z",
+                "command": "search.focus.nextInputBox",
+                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys"
+            },
+            {
+                "key": "ctrl+m",
+                "command": "search.action.openResult",
+                "when": "fileMatchOrMatchFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys"
             }
         ]
     },


### PR DESCRIPTION
SEARCHの入力欄と検索結果の間でフォーカスを移動する操作として、VS Codeのデフォルトでは

- CTRL+カーソル下
- CTRL+カーソル上

が使えます。
これをダイアモンドカーソルの CTRL+Z と CTRL+W に割り当てます。

なお、検討した他の候補のキーは以下の通り：

- CTRL+E, CTRL+Xは入力欄では履歴の参照、検索結果欄ではリストの選択にすでに使われています。
- CTRL+R, CTRL+Cは入力欄では使われませんが、検索結果欄ではリストのスクロールにすでに使われています。

そのため、やや変則的ですがVS Codeのデフォルトに寄せるためにCTRL+W, CTRL+Zとしてみました。
