### PR TITLE
Fix CTRL+W and CTRL+Z to respect settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1289,12 +1289,12 @@
             {
                 "key": "ctrl+w",
                 "command": "list.scrollUp",
-                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys"
+                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys && config.vzKeymap.ctrl+W"
             },
             {
                 "key": "ctrl+z",
                 "command": "list.scrollDown",
-                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys"
+                "when": "listFocus && !inputFocus && config.vzKeymap.listViewKeys && config.vzKeymap.ctrl+Z"
             },
             {
                 "key": "ctrl+m",
@@ -1464,12 +1464,12 @@
             {
                 "key": "ctrl+w",
                 "command": "search.focus.previousInputBox",
-                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys"
+                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys && config.vzKeymap.ctrl+W"
             },
             {
                 "key": "ctrl+z",
                 "command": "search.focus.nextInputBox",
-                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys"
+                "when": "searchViewletFocus && searchViewletVisible && config.vzKeymap.searchViewletKeys && config.vzKeymap.ctrl+Z"
             },
             {
                 "key": "ctrl+m",


### PR DESCRIPTION
Vz Keymapとしてはまだリリース前の機能として、Searchビューでの操作およびリストビューでの操作において、CTRL+WとCTRL+Zの割り当てを行ったが、これらがVz Keymapの設定でCTRL+WやCTRL+Zの割り当てを無効にしている場合でも割り当てられてしまう問題があるので、これを修正する。

設定の**Vz Keymap: Ctrl+W**や**Vz Keymap: Ctrl+Z**はこれらのキーをVz Keymapに割り当てたくない場合にオフにする。
これにより、CTRL+Wでタブを閉じたり、CTRL+ZでUndoする、といったVS Codeのデフォルトの操作を維持することができる。

そのような設定をしている場合は、SearchビューやリストビューでもこれらのキーにはVz Keymapのキー割り当ては行わない。
