### PR TITLE
Widget Navigation Keysの追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Vz Keymap extension will be documented in this file.
 
+### [Unreleased]
+- 新規:
+    - ウィジェット間のフォーカス移動操作に対応しました。 [#190](https://github.com/tshino/vscode-vz-like-keymap/pull/190)
+        - これは `widgetNavigation.focusPrevious` と `widgetNavigation.focusNext` コマンドに対応し、一例としては Keyboard Shortcuts の画面で検索入力と検索結果の間でフォーカスを移動するときに使えます。
+        - CTRL+W, CTRL+Z でフォーカスを移動。
+        - これらは設定の 'Vz Keymap: Widget Navigation Keys' で有効化できます。デフォルトで有効です。
+- New:
+    - Added navigation keys support in navigable widget containers. [#190](https://github.com/tshino/vscode-vz-like-keymap/pull/190)
+        - Ctrl+W, Ctrl+Z to move focus over widgets in widget containers.
+        - These keys are enabled by turning on the 'Vz Keymap: Widget Navigation Keys' in the Settings.
+
 ### [0.19.9] - 2023-08-10
 - 新規:
     - Searchビューで使う操作に対応しました。 [#181](https://github.com/tshino/vscode-vz-like-keymap/pull/181)

--- a/package.json
+++ b/package.json
@@ -256,6 +256,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enables vz-style keys to move focus on the Status Bar\n(Ctrl+S, Ctrl+D, Ctrl+A, Ctrl+F, Ctrl+Q S, Ctrl+Q D)"
+                },
+                "vzKeymap.widgetNavigationKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to move focus over widgets in widget containers\n(Ctrl+W, Ctrl+Z)"
                 }
             }
         },
@@ -1513,6 +1518,16 @@
                 "key": "ctrl+q d",
                 "command": "workbench.statusBar.focusLast",
                 "when": "statusBarFocused && config.vzKeymap.statusBarKeys"
+            },
+            {
+                "key": "ctrl+w",
+                "command": "widgetNavigation.focusPrevious",
+                "when": "inputFocus && navigableContainerFocused && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+W || navigableContainerFocused && !listFocus && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+W || navigableContainerFocused && listScrollAtBoundary == 'both' && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+W || navigableContainerFocused && listScrollAtBoundary == 'top' && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+W"
+            },
+            {
+                "key": "ctrl+z",
+                "command": "widgetNavigation.focusNext",
+                "when": "inputFocus && navigableContainerFocused && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+Z || navigableContainerFocused && !listFocus && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+Z || navigableContainerFocused && listScrollAtBoundary == 'both' && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+Z || navigableContainerFocused && listScrollAtBoundary == 'bottom' && config.vzKeymap.widgetNavigationKeys && config.vzKeymap.ctrl+Z"
             }
         ]
     },


### PR DESCRIPTION
エディタ以外の場所でデフォルトキーバインドの CTRL+UP と CTRL+DOWN が割り当てられている操作として、以下の2つがあります（Windows版VS Code）。
```json
{
  "key": "ctrl+up",
  "command": "widgetNavigation.focusPrevious",
  "when": "inputFocus && navigableContainerFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'top'"
},
{
  "key": "ctrl+down",
  "command": "widgetNavigation.focusNext",
  "when": "inputFocus && navigableContainerFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'bottom'"
}
```
`navigableContainerFocused`というコンテキストの解説が見つからないのでどんな場所に適用されるか不明ですが、
一例として、Keyboard Shortcutsの画面で検索入力ボックスと検索結果リストの間でのフォーカスの移動に使えることが分かりました。
この操作は便利なので、SEARCHビューでのキー追加 #181 と同様に CTRL+W と CTRL+Z を割り当てることにします。

これらはVz Keymapの設定で CTRL+W や CTRL+Z をそれぞれ無効にしている場合は割り当てないようにします。