### PR TITLE
Notificationのキー操作の追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ All notable changes to the Vz Keymap extension will be documented in this file.
         - これは `widgetNavigation.focusPrevious` と `widgetNavigation.focusNext` コマンドに対応し、一例としては Keyboard Shortcuts の画面で検索入力と検索結果の間でフォーカスを移動するときに使えます。
         - CTRL+W, CTRL+Z でフォーカスを移動。
         - これらは設定の 'Vz Keymap: Widget Navigation Keys' で有効化できます。デフォルトで有効です。
+    - 通知リストの操作に対応しました。 [#191](https://github.com/tshino/vscode-vz-like-keymap/pull/191)
+        - CTRL+E, CTRL+X などの上下のフォーカス移動操作はリストビューの操作（設定項目 List View Keys）として対応済み。
+        - CTRL+S, CTRL+D, CTRL+M で通知項目の縮小、展開およびトグル。
+        - これらは設定の 'Vz Keymap: Notification Keys' で有効化できます。デフォルトで有効です。
 - New:
     - Added navigation keys support in navigable widget containers. [#190](https://github.com/tshino/vscode-vz-like-keymap/pull/190)
         - Ctrl+W, Ctrl+Z to move focus over widgets in widget containers.
         - These keys are enabled by turning on the 'Vz Keymap: Widget Navigation Keys' in the Settings.
+    - Added navigation keys support on Notifications. [#191](https://github.com/tshino/vscode-vz-like-keymap/pull/191)
+        - Vertical navigation keys such as Ctrl+E and Ctrl+X are already supported as List View Keys.
+        - CtrL+S, Ctrl+D, Ctrl+M to collapse/expand/toggle a notification item.
+        - These keys are enabled by turning on the 'Vz Keymap: Notification Keys' in the Settings.
 
 ### [0.19.9] - 2023-08-10
 - 新規:

--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
                     "default": true,
                     "description": "Enables vz-style keys to move focus on the Status Bar\n(Ctrl+S, Ctrl+D, Ctrl+A, Ctrl+F, Ctrl+Q S, Ctrl+Q D)"
                 },
+                "vzKeymap.notificationKeys": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables vz-style keys to move focus on the Notifications\n(Ctrl+S, Ctrl+D, Ctrl+M)\nOther keys such as Ctrl+E, Ctrl+X are enabled by List View Keys"
+                },
                 "vzKeymap.widgetNavigationKeys": {
                     "type": "boolean",
                     "default": true,
@@ -1393,6 +1398,21 @@
                 "key": "ctrl+m",
                 "command": "acceptSelectedCodeAction",
                 "when": "codeActionMenuVisible && config.vzKeymap.codeActionKeys"
+            },
+            {
+                "key": "ctrl+s",
+                "command": "notification.collapse",
+                "when": "notificationFocus && config.vzKeymap.notificationKeys"
+            },
+            {
+                "key": "ctrl+d",
+                "command": "notification.expand",
+                "when": "notificationFocus && config.vzKeymap.notificationKeys"
+            },
+            {
+                "key": "ctrl+m",
+                "command": "notification.toggle",
+                "when": "notificationFocus && config.vzKeymap.notificationKeys"
             },
             {
                 "key": "ctrl+e",


### PR DESCRIPTION
Notification（右下にポップアップする通知）にフォーカスがあるときのキー操作を追加します。

通常、Notificationにフォーカスが自動で移ることはありませんが、Notifications: Show Notifications コマンドを使うと現在溜まっているすべての通知項目が縦に並べて表示され、カーソル上下で選んだり、Deleteで項目を消したりできます。
このときの上下のフォーカス移動はすでに Explorer のファイルツリーなどと共通のコマンドのため、設定項目 Vz Keymap: List View Keys で有効になっています。
ですが、通知項目をカーソル左右で展開・縮小する操作とEnterキーでそれをトグルする操作はリスト系とはコマンドが異なるため未対応でした。
そのため、それらの操作もVZスタイルでできるようにします。
